### PR TITLE
Quitar acento icono y resaltado pull request

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -8,7 +8,7 @@ Aprender en público significa colaboración y no tienes que ser un experto para
 
 ![editar en Github](https://github.com/breatheco-de/the-misspell-chalenge/blob/master/assets/github-logo2.png?raw=true)
 
-1. Haz clic en el ícono del lápiz que dice "Editar en Github" en la parte superior derecha de la lección, y el archivo fuente de la lección será editable.
+1. Haz clic en el icono del lápiz que dice "Editar en Github" en la parte superior derecha de la lección, y el archivo fuente de la lección será editable.
 
 2. Corrige el error ortográfico de la lección.
 
@@ -16,7 +16,7 @@ Aprender en público significa colaboración y no tienes que ser un experto para
 
 ## 📝 Instrucciones:
 
-1. Encuentra un error ortográfico en las lecciones, proyectos o ejercicios de 4Geeks y crea un `pull request` con la solución.
+1. Encuentra un error ortográfico en las lecciones, proyectos o ejercicios de 4Geeks y crea un **pull request** con la solución.
 
 > 👉 **IMPORTANTE**: busca otro proyecto para corregir, este proyecto ya se ha corregido lo suficiente 😂
 


### PR DESCRIPTION
La palabra icono en español castellano no lleva acento. En el español latinoamericano sí que lleva el acento. Además, he resaltado la palabra pull request para que pueda visualizarse más fácilmente. 