### PR TITLE
Corregido el error en la liga de editar en Github, ya que estaba como…

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -6,7 +6,7 @@ Aprender en público significa colaboración y no tienes que ser un experto para
  
 ## 🔷 Cómo corregir un error ortográfico en una lección de 4Geeks:  
 
-![editar en Github](https://github.com/breatheco-de/the-misspell-chalenge/blob/master/assets/github-logo2.png?raw=true)
+![editar en Github](https://github.com/breatheco-de/the-misspell-challenge/blob/master/assets/github-logo2.png?raw=true)
 
 1. Haz clic en el ícono del lápiz que dice "Editar en Github" en la parte superior derecha de la lección, y el archivo fuente de la lección será editable.
 


### PR DESCRIPTION
El nombre del repositorio está escrito como the-misspell-**chalenge**, pero la palabra correcta en inglés es challenge (con dos "l").