### PR TITLE
Create misspelled Ecom

### DIFF
--- a/misspelled Ecom
+++ b/misspelled Ecom
@@ -1,0 +1,5 @@
+A bit of history about the project
+Before the domain market was centralized and converted into a mafia controlled by Godaddy, Ecom, and others, normal people like you and me were able to buy a .com domain relatively easily.
+
+In fact, this project was originally built in 2002 by one of the 4Geeks teachers while he was trying to find domain names to buy for several projects.
+


### PR DESCRIPTION
In this lesson word ECOM was spelled Enom. It is now corrected.