### PR TITLE
Fix typo in GitHub link instruction

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -8,7 +8,7 @@ Aprender en público significa colaboración y no tienes que ser un experto para
 
 ![editar en Github](https://github.com/breatheco-de/the-misspell-chalenge/blob/master/assets/github-logo2.png?raw=true)
 
-1. Haz clic en el ícono del lápiz que dice "Editar en Github" en la parte superior derecha de la lección, y el archivo fuente de la lección será editable.
+1. Haz clic en el ícono del lápiz que dice "Editar en GitHub" en la parte superior derecha de la lección, y el archivo fuente de la lección será editable.
 
 2. Corrige el error ortográfico de la lección.
 


### PR DESCRIPTION
He cambiado Github por GitHub para demostrar que se.